### PR TITLE
不要なshaderの設定をしないように

### DIFF
--- a/project-game/GameProject/BillboardShader.cpp
+++ b/project-game/GameProject/BillboardShader.cpp
@@ -65,7 +65,7 @@ BillboardShader::~BillboardShader()
 /*------------------------------------------------------------------------------
 	シェーダーをセット
 ------------------------------------------------------------------------------*/
-void BillboardShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial)
+void BillboardShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet)
 {
 	LPDIRECT3DDEVICE9 pDevice = Manager::GetDevice();	//デバイスのポインタ
 
@@ -80,11 +80,14 @@ void BillboardShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMater
 	mtxViewInverse._24 = 0.0f;
 	mtxViewInverse._34 = 0.0f;
 
-	//頂点宣言
-	pDevice->SetVertexDeclaration( m_pVertexDec);
+	if( !isAlreadySet)
+	{
+		//頂点宣言
+		pDevice->SetVertexDeclaration( m_pVertexDec);
 
-	//テクニックの設定
-	m_pEffect->SetTechnique( m_hTech);
+		//テクニックの設定
+		m_pEffect->SetTechnique( m_hTech);
+	}
 
 	//定数をシェーダに伝える
 	m_pEffect->SetMatrix( m_hMtxPos, &mtxPos);

--- a/project-game/GameProject/BillboardShader.h
+++ b/project-game/GameProject/BillboardShader.h
@@ -21,7 +21,7 @@ class BillboardShader : public Shader
 public:
 	BillboardShader();
 	~BillboardShader();
-	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial);
+	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet);
 private:
 	D3DXHANDLE m_hTech;
 	D3DXHANDLE m_hMtxPos;

--- a/project-game/GameProject/DefaultShader.cpp
+++ b/project-game/GameProject/DefaultShader.cpp
@@ -63,15 +63,18 @@ DefaultShader::~DefaultShader()
 /*------------------------------------------------------------------------------
 	シェーダーをセット
 ------------------------------------------------------------------------------*/
-void DefaultShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial)
+void DefaultShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet)
 {
 	LPDIRECT3DDEVICE9 pDevice = Manager::GetDevice();	//デバイスのポインタ
 
-	//頂点宣言
-	pDevice->SetVertexDeclaration( m_pVertexDec);
+	if( !isAlreadySet)
+	{
+		//頂点宣言
+		pDevice->SetVertexDeclaration( m_pVertexDec);
 
-	//テクニックの設定
-	m_pEffect->SetTechnique( m_hTech);
+		//テクニックの設定
+		m_pEffect->SetTechnique( m_hTech);
+	}
 
 	//定数をシェーダに伝える
 	m_pEffect->SetMatrix( m_hMtxWorld, &pRenderer->m_pTransform->WorldMatrix());

--- a/project-game/GameProject/DefaultShader.h
+++ b/project-game/GameProject/DefaultShader.h
@@ -21,7 +21,7 @@ class DefaultShader : public Shader
 public:
 	DefaultShader();
 	~DefaultShader();
-	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial);
+	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet);
 private:
 	D3DXHANDLE m_hTech;
 	D3DXHANDLE m_hMtxWorld;

--- a/project-game/GameProject/DepthShader.cpp
+++ b/project-game/GameProject/DepthShader.cpp
@@ -59,15 +59,18 @@ DepthShader::~DepthShader()
 /*------------------------------------------------------------------------------
 	シェーダーをセット
 ------------------------------------------------------------------------------*/
-void DepthShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial)
+void DepthShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet)
 {
 	LPDIRECT3DDEVICE9 pDevice = Manager::GetDevice();	//デバイスのポインタ
 
-	//頂点宣言
-	pDevice->SetVertexDeclaration( m_pVertexDec);
+	if( !isAlreadySet)
+	{
+		//頂点宣言
+		pDevice->SetVertexDeclaration( m_pVertexDec);
 
-	//テクニックの設定
-	m_pEffect->SetTechnique( m_hTech);
+		//テクニックの設定
+		m_pEffect->SetTechnique( m_hTech);
+	}
 
 	//定数をシェーダに伝える
 	m_pEffect->SetMatrix( m_hMtxWorld, &pRenderer->m_pTransform->WorldMatrix());

--- a/project-game/GameProject/DepthShader.h
+++ b/project-game/GameProject/DepthShader.h
@@ -21,7 +21,7 @@ class DepthShader : public Shader
 public:
 	DepthShader();
 	~DepthShader();
-	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial);
+	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet);
 private:
 	D3DXHANDLE m_hTech;
 	D3DXHANDLE m_hMtxWorld;

--- a/project-game/GameProject/Material.cpp
+++ b/project-game/GameProject/Material.cpp
@@ -76,8 +76,7 @@ Material::~Material()
 ------------------------------------------------------------------------------*/
 void Material::Set( Camera* pCamera, Renderer* pRenderer)
 {
-	auto pShader = Manager::GetShaderManager()->Load( m_ShaderType);
-	pShader->Set( pCamera, pRenderer, this);
+	Manager::GetShaderManager()->SetShader( pCamera, pRenderer, this, m_ShaderType);
 }
 
 /*------------------------------------------------------------------------------

--- a/project-game/GameProject/ModeGame.cpp
+++ b/project-game/GameProject/ModeGame.cpp
@@ -74,11 +74,6 @@ void ModeGame::Init()
 	//City
 	auto cityObject = new GameObject( m_pRoot);
 	auto cityController = cityObject->AddComponent<CityController>();
-
-	auto carObject = new GameObject( m_pRoot);
-	//auto carRenderer = carObject->AddComponent<XModelRenderer>();
-	//carRenderer->LoadXModel( "data/MODEL/car.x");
-	
 }
 
 /*------------------------------------------------------------------------------

--- a/project-game/GameProject/ParticleShader.cpp
+++ b/project-game/GameProject/ParticleShader.cpp
@@ -65,15 +65,18 @@ ParticleShader::~ParticleShader()
 /*------------------------------------------------------------------------------
 	シェーダーをセット
 ------------------------------------------------------------------------------*/
-void ParticleShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial)
+void ParticleShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet)
 {
 	LPDIRECT3DDEVICE9 pDevice = Manager::GetDevice();	//デバイスのポインタ
 
-	//頂点宣言
-	pDevice->SetVertexDeclaration( m_pVertexDec);
+	if( !isAlreadySet)
+	{
+		//頂点宣言
+		pDevice->SetVertexDeclaration( m_pVertexDec);
 
-	//テクニックの設定
-	m_pEffect->SetTechnique( m_hTech);
+		//テクニックの設定
+		m_pEffect->SetTechnique( m_hTech);
+	}
 
 	//定数をシェーダに伝える
 	D3DXMATRIX mtxWorld = pRenderer->m_pTransform->WorldMatrix() * *pCamera->GetViewMatrix() * *pCamera->GetProjectionMatrix();

--- a/project-game/GameProject/ParticleShader.h
+++ b/project-game/GameProject/ParticleShader.h
@@ -21,7 +21,7 @@ class ParticleShader : public Shader
 public:
 	ParticleShader();
 	~ParticleShader();
-	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial);
+	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet);
 private:
 	D3DXHANDLE m_hTech;
 	D3DXHANDLE m_hMtxWVP;

--- a/project-game/GameProject/PerPixelLightingShader.cpp
+++ b/project-game/GameProject/PerPixelLightingShader.cpp
@@ -75,18 +75,21 @@ PerPixelLightingShader::~PerPixelLightingShader()
 /*------------------------------------------------------------------------------
 	シェーダーをセット
 ------------------------------------------------------------------------------*/
-void PerPixelLightingShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial)
+void PerPixelLightingShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet)
 {
 	D3DXMATRIX mtxWorldInv = pRenderer->m_pTransform->WorldMatrix();
 	D3DXMatrixInverse( &mtxWorldInv, NULL, &mtxWorldInv);
 
 	LPDIRECT3DDEVICE9 pDevice = Manager::GetDevice();	//デバイスのポインタ
 
-	//頂点宣言
-	pDevice->SetVertexDeclaration( m_pVertexDec);
+	if( !isAlreadySet)
+	{
+		//頂点宣言
+		pDevice->SetVertexDeclaration( m_pVertexDec);
 
-	//テクニックの設定
-	m_pEffect->SetTechnique( m_hTech);
+		//テクニックの設定
+		m_pEffect->SetTechnique( m_hTech);
+	}
 
 	//定数をシェーダに伝える
 	m_pEffect->SetMatrix( m_hMtxWorld, &pRenderer->m_pTransform->WorldMatrix());

--- a/project-game/GameProject/PerPixelLightingShader.h
+++ b/project-game/GameProject/PerPixelLightingShader.h
@@ -21,7 +21,7 @@ class PerPixelLightingShader : public Shader
 public:
 	PerPixelLightingShader();
 	~PerPixelLightingShader();
-	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial);
+	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet);
 private:
 	D3DXHANDLE m_hTech;
 	D3DXHANDLE m_hMtxWorld;

--- a/project-game/GameProject/Shader.h
+++ b/project-game/GameProject/Shader.h
@@ -26,7 +26,7 @@ class Shader
 {
 public:
 	virtual ~Shader(){}
-	virtual void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial) = 0;
+	virtual void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet) = 0;
 
 	void Begin(int nPass)
 	{

--- a/project-game/GameProject/ShaderManager.cpp
+++ b/project-game/GameProject/ShaderManager.cpp
@@ -23,7 +23,7 @@
 /*------------------------------------------------------------------------------
 	コンストラクタ
 ------------------------------------------------------------------------------*/
-ShaderManager::ShaderManager()
+ShaderManager::ShaderManager() : m_CurrentShader( NULL)
 {
 	//シェーダーのロード
 	m_vecShaderSet.clear();
@@ -64,6 +64,23 @@ ShaderManager::~ShaderManager()
 	m_mapShaderLoad.clear();
 
 	m_vecShaderSet.clear();
+}
+
+/*------------------------------------------------------------------------------
+	シェーダーをロード
+------------------------------------------------------------------------------*/
+void ShaderManager::SetShader( Camera* pCamera, Renderer* pRenderer, Material* pMaterial, EShaderType Type)
+{
+	auto shader = Load( Type);
+	if (m_CurrentShader == shader)
+	{
+		shader->Set( pCamera, pRenderer, pMaterial, true);
+	}
+	else
+	{
+		shader->Set( pCamera, pRenderer, pMaterial, false);
+		m_CurrentShader = shader;
+	}
 }
 
 /*------------------------------------------------------------------------------

--- a/project-game/GameProject/ShaderManager.h
+++ b/project-game/GameProject/ShaderManager.h
@@ -16,6 +16,9 @@
 	前方宣言
 ------------------------------------------------------------------------------*/
 class Shader;
+class Camera;
+class Renderer;
+class Material;
 
 /*------------------------------------------------------------------------------
 	列挙型定義
@@ -41,7 +44,8 @@ public:
 	ShaderManager();
 	~ShaderManager();
 
-	Shader *Load( EShaderType Type);
+	void SetShader( Camera* pCamera, Renderer* pRenderer, Material* pMaterial, EShaderType Type);
+	Shader* Load( EShaderType Type);
 
 	void SetDefault( void);
 	void SetOnShadow( void);
@@ -50,7 +54,8 @@ public:
 private:
 	std::vector<Shader*> m_vecShaderSet;							//セットするシェーダー
 	std::unordered_map< std::string, Shader*> m_mapShaderLoad;		//読み込み済みシェーダー
-
+	Shader* m_CurrentShader;
+	
 };
 
 

--- a/project-game/GameProject/ShadowVLShader.cpp
+++ b/project-game/GameProject/ShadowVLShader.cpp
@@ -73,7 +73,7 @@ ShadowVLShader::~ShadowVLShader()
 /*------------------------------------------------------------------------------
 	シェーダーをセット
 ------------------------------------------------------------------------------*/
-void ShadowVLShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial)
+void ShadowVLShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet)
 {
 	//逆行列の設定
 	D3DXMATRIX mtxWorldInv = pRenderer->m_pTransform->WorldMatrix();
@@ -99,11 +99,14 @@ void ShadowVLShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMateri
 
 	LPDIRECT3DDEVICE9 pDevice = Manager::GetDevice();	//デバイスのポインタ
 
-	//頂点宣言
-	pDevice->SetVertexDeclaration( m_pVertexDec);
+	if( !isAlreadySet)
+	{
+		//頂点宣言
+		pDevice->SetVertexDeclaration( m_pVertexDec);
 
-	//テクニックの設定
-	m_pEffect->SetTechnique( m_hTech);
+		//テクニックの設定
+		m_pEffect->SetTechnique( m_hTech);
+	}
 
 	//定数をシェーダに伝える
 	m_pEffect->SetMatrix( m_hMtxWorld, &pRenderer->m_pTransform->WorldMatrix());

--- a/project-game/GameProject/ShadowVLShader.h
+++ b/project-game/GameProject/ShadowVLShader.h
@@ -21,7 +21,7 @@ class ShadowVLShader : public Shader
 public:
 	ShadowVLShader();
 	~ShadowVLShader();
-	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial);
+	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet);
 private:
 	D3DXHANDLE m_hTech;
 	D3DXHANDLE m_hMtxWorld;

--- a/project-game/GameProject/SkinMeshShader.cpp
+++ b/project-game/GameProject/SkinMeshShader.cpp
@@ -77,18 +77,21 @@ SkinMeshShader::~SkinMeshShader()
 /*------------------------------------------------------------------------------
 	シェーダーをセット
 ------------------------------------------------------------------------------*/
-void SkinMeshShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial)
+void SkinMeshShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet)
 {
 	D3DXMATRIX mtxWorldInv = pRenderer->m_pTransform->WorldMatrix();
 	D3DXMatrixInverse( &mtxWorldInv, NULL, &mtxWorldInv);
 
 	LPDIRECT3DDEVICE9 pDevice = Manager::GetDevice();	//デバイスのポインタ
 	
-	//頂点宣言
-	pDevice->SetVertexDeclaration( m_pVertexDec);
+	if( !isAlreadySet)
+	{
+		//頂点宣言
+		pDevice->SetVertexDeclaration( m_pVertexDec);
 
-	//テクニックの設定
-	m_pEffect->SetTechnique( m_hTech);
+		//テクニックの設定
+		m_pEffect->SetTechnique( m_hTech);
+	}
 
 	//定数をシェーダに伝える
 	m_pEffect->SetMatrix( m_hMtxWorld, &pRenderer->m_pTransform->WorldMatrix());

--- a/project-game/GameProject/SkinMeshShader.h
+++ b/project-game/GameProject/SkinMeshShader.h
@@ -21,7 +21,7 @@ class SkinMeshShader : public Shader
 public:
 	SkinMeshShader();
 	~SkinMeshShader();
-	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial);
+	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet);
 private:
 	D3DXHANDLE m_hTech;
 	D3DXHANDLE m_hMtxWorld;

--- a/project-game/GameProject/SpriteShader.cpp
+++ b/project-game/GameProject/SpriteShader.cpp
@@ -59,15 +59,18 @@ SpriteShader::~SpriteShader()
 /*------------------------------------------------------------------------------
 	シェーダーをセット
 ------------------------------------------------------------------------------*/
-void SpriteShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial)
+void SpriteShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet)
 {
 	LPDIRECT3DDEVICE9 pDevice = Manager::GetDevice();	//デバイスのポインタ
 
-	//頂点宣言
-	pDevice->SetVertexDeclaration( m_pVertexDec);
+	if( !isAlreadySet)
+	{
+		//頂点宣言
+		pDevice->SetVertexDeclaration( m_pVertexDec);
 
-	//テクニックの設定
-	m_pEffect->SetTechnique( m_hTech);
+		//テクニックの設定
+		m_pEffect->SetTechnique( m_hTech);
+	}
 
 	//定数をシェーダに伝える
 	m_pEffect->SetTexture( m_hTexture, pMaterial->GetTexture());

--- a/project-game/GameProject/SpriteShader.h
+++ b/project-game/GameProject/SpriteShader.h
@@ -21,7 +21,7 @@ class SpriteShader : public Shader
 public:
 	SpriteShader();
 	~SpriteShader();
-	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial);
+	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet);
 private:
 	D3DXHANDLE m_hTech;
 	D3DXHANDLE m_hTexture;

--- a/project-game/GameProject/VertexLightingShader.cpp
+++ b/project-game/GameProject/VertexLightingShader.cpp
@@ -71,18 +71,21 @@ VertexLightingShader::~VertexLightingShader()
 /*------------------------------------------------------------------------------
 	シェーダーをセット
 ------------------------------------------------------------------------------*/
-void VertexLightingShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial)
+void VertexLightingShader::Set(Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet)
 {
 	D3DXMATRIX mtxWorldInv = pRenderer->m_pTransform->WorldMatrix();
 	D3DXMatrixInverse( &mtxWorldInv, NULL, &mtxWorldInv);
 
 	LPDIRECT3DDEVICE9 pDevice = Manager::GetDevice();	//デバイスのポインタ
 
-	//頂点宣言
-	pDevice->SetVertexDeclaration( m_pVertexDec);
+	if( !isAlreadySet)
+	{
+		//頂点宣言
+		pDevice->SetVertexDeclaration( m_pVertexDec);
 
-	//テクニックの設定
-	m_pEffect->SetTechnique( m_hTech);
+		//テクニックの設定
+		m_pEffect->SetTechnique( m_hTech);
+	}
 
 	//定数をシェーダに伝える
 	m_pEffect->SetMatrix( m_hMtxWorld, &pRenderer->m_pTransform->WorldMatrix());

--- a/project-game/GameProject/VertexLightingShader.h
+++ b/project-game/GameProject/VertexLightingShader.h
@@ -21,7 +21,7 @@ class VertexLightingShader : public Shader
 public:
 	VertexLightingShader();
 	~VertexLightingShader();
-	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial);
+	void Set( Camera* pCamera, Renderer* pRenderer, Material* pMaterial, bool isAlreadySet);
 private:
 	D3DXHANDLE m_hTech;
 	D3DXHANDLE m_hMtxWorld;


### PR DESCRIPTION
すでに同じシェーダーが読み込まれていた場合、頂点宣言の設定とテクニックの設定を省く